### PR TITLE
Avoid deprecated `MethodDescriptor.create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin"          % "0.6.6",
-  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.4"
+  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.5"
 )
 ```
 
@@ -42,7 +42,7 @@ PB.targets in Compile := Seq(
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.4"
+libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.5"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization in ThisBuild := "beyondthelines"
-version in ThisBuild := "0.0.4"
+version in ThisBuild := "0.0.5-SNAPSHOT"
 bintrayOrganization in ThisBuild := Some(sys.props.get("bintray.organization").getOrElse("beyondthelines"))
 bintrayRepository in ThisBuild := "maven"
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc", "akka")


### PR DESCRIPTION
`MethodDescriptor.create` is deprecated in favour of a builder pattern `MethodDescriptor.newBuilder()`