### PR TITLE
Add support for multiple services within one proto file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin"          % "0.6.7",
-  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.6"
+  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.7"
 )
 ```
 
@@ -42,7 +42,7 @@ PB.targets in Compile := Seq(
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.6"
+libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.7"
 ```
 
 ### Usage
@@ -51,7 +51,7 @@ You're now ready to implement your GRPC service using Akka-streams Flow.
 
 To implement your service's business logic you simply extend the GRPCAkkaStream generated trait.
 
-E.g. for the RouteGuide service: 
+E.g. for the RouteGuide service:
 
 ```scala
 class RouteGuideAkkaStreamService(features: Seq[Feature]) extends RouteGuideGrpcAkkaStream.RouteGuide {
@@ -78,7 +78,7 @@ val server = ServerBuilder
       new RouteGuideAkkaStreamService(features) // the service implemented above
     )
   )
-  .build()    
+  .build()
 ```
 
 Akka-streams' Flows are also available on the client side:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization in ThisBuild := "beyondthelines"
-version in ThisBuild := "0.0.6"
+version in ThisBuild := "0.0.7"
 bintrayOrganization in ThisBuild := Some(sys.props.get("bintray.organization").getOrElse("beyondthelines"))
 bintrayRepository in ThisBuild := "maven"
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc", "akka")

--- a/generator/src/main/scala/grpc/akkastreams/generators/GrpcAkkaStreamGenerator.scala
+++ b/generator/src/main/scala/grpc/akkastreams/generators/GrpcAkkaStreamGenerator.scala
@@ -210,6 +210,7 @@ class GrpcAkkaStreamGenerator(override val params: GeneratorParams)
         .add("})")
         .outdent
         .add(")")
+        .outdent
       case ClientStreaming => printer
         .add(s"override ${serviceMethodSignature(method)} =")
         .indent


### PR DESCRIPTION
Having multiple service definitions within one proto file currently causes `grpcakkastream` to generate invalid code:

<details>
<summary><b>test_service.proto</b> (click to expand)</summary>
<pre>
service TestService1 { ... }
service TestService2 { ... }
</pre>
</details>

<details>
<summary><b>Compilation output</b> (click to expand)</summary>
<pre>
[error] ./target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala:200
         SERVICE is already defined as value SERVICE
[error]     val SERVICE: _root_.io.grpc.ServiceDescriptor = _root_.io.grpc.ServiceDescriptor.newBuilder("rpclib.TestService2")
[error]         ^
[error] ./src/main/scala/com/tubitv/rpclib/DemoClient.scala:24
         ambiguous reference to overloaded definition,
[error] both method stub in object TestServiceGrpcAkkaStream of type (channel: io.grpc.Channel)com.tubitv.rpc.TestServiceGrpcAkkaStream.TestService2Stub
[error] and  method stub in object TestServiceGrpcAkkaStream of type (channel: io.grpc.Channel)com.tubitv.rpc.TestServiceGrpcAkkaStream.TestService1Stub
[error] match argument types (io.grpc.ManagedChannel)
[error]   val service = TestServiceGrpcAkkaStream.stub(channel)
[error]                                           ^
[error] ./target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala:255
         method javaDescriptor is defined twice
[error]   conflicting symbols both originated in file './target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala'
[error]     def javaDescriptor: ServiceDescriptor =
[error]         ^
[error] ./target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala:253
         method stub is defined twice
[error]   conflicting symbols both originated in file './target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala'
[error]     def stub(channel: Channel): TestService2Stub = new TestService2Stub(channel)
[error]         ^
[error] four errors found
[error] (compile:compileIncremental) Compilation failed
</pre>
</details>

<br/>
<p>
This PR adds support for multiple services defined within one proto file by using ScalaPB’s convention of keeping generated service code in separate Scala files.
</p>

<hr/>

Note that this introduces a small breaking change.  Using the above proto file as an example:

**Before**: One Scala file would be generated with the filename `TestServiceGrpcAkkaStream.scala`.

**After**: Two Scala files would be generated with the filenames `TestService1GrpcAkkaStream.scala` and `TestService2GrpcAkkaStream.scala`, mirroring ScalaPB’s two files `TestService1Grpc.scala` and `TestService2Grpc.scala`.