### PR TITLE
Fix name clashes with AnyRef’s methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin"          % "0.6.7",
-  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.7"
+  "beyondthelines"         %% "grpcakkastreamgenerator" % "0.0.8"
 )
 ```
 
@@ -42,7 +42,7 @@ PB.targets in Compile := Seq(
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.7"
+libraryDependencies += "beyondthelines" %% "grpcakkastreamruntime" % "0.0.8"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization in ThisBuild := "beyondthelines"
-version in ThisBuild := "0.0.7"
+version in ThisBuild := "0.0.8"
 bintrayOrganization in ThisBuild := Some(sys.props.get("bintray.organization").getOrElse("beyondthelines"))
 bintrayRepository in ThisBuild := "maven"
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc", "akka")


### PR DESCRIPTION
gRPC methods named `clone`, `finalize`, `notify`, `notifyAll`, or `wait` currently cause `grpcakkastream` to generate invalid code:

<details>
<summary><b>Compilation output</b> (click to expand)</summary>
<pre>
[error] ./target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala:383
         type mismatch;
[error]  found   : Unit
[error]  required: akka.stream.Graph[akka.stream.FlowShape[com.tubitv.rpc.In,?],?]
[error]                 .via(serviceImpl.notify)
[error]                                  ^
[error] ./target/scala-2.11/src_managed/main/com/tubitv/rpc/TestServiceGrpcAkkaStream.scala:384
         missing argument list for method onNext in trait StreamObserver
[error] Unapplied methods are only converted to functions when a function type is expected.
[error] You can make this conversion explicit by writing `onNext _` or `onNext(_)` instead of `onNext`.
[error]                 .runForeach(responseObserver.onNext)
[error]                                              ^
[error] two errors found
[error] (compile:compileIncremental) Compilation failed
</pre>
</details>

<br/>

This occurs because these five parameterless methods are marked `final` (or, in the case of `clone`, `protected`) in `AnyRef`.  Generating a homonymous method leads the Scala compiler to think we’re trying to override these methods.

This PR fixes this issue by appending an underscore to these method names in the generated code.